### PR TITLE
enable login localdev workaround

### DIFF
--- a/dfds-deploy/READMEmd
+++ b/dfds-deploy/READMEmd
@@ -27,3 +27,7 @@ Add this entry:
 127.0.0.1 localdev
 
 Save and close
+
+Then update .env file with the following values (port number can be modified as desired)
+APP_CONFIG_app_baseUrl=http://localdev:3000
+BACKEND_CORS_ORIGIN=http://localdev:3000

--- a/dfds-deploy/READMEmd
+++ b/dfds-deploy/READMEmd
@@ -17,3 +17,13 @@ to stop docker compose, open new terminal window and run this in the root of the
 yarn docker-compose:stop
 ```
 
+
+### Enabling Micorsoft login on local Dev environment using docer on Windows and WSL
+
+Open this file using Run as Administrator:
+C:\Windows\System32\drivers\etc\hosts
+
+Add this entry:
+127.0.0.1 localdev
+
+Save and close

--- a/dfds-deploy/docker-compose.dev.yaml
+++ b/dfds-deploy/docker-compose.dev.yaml
@@ -33,9 +33,11 @@ services:
     volumes:
       - ../:/app
     ports:
-      - '3000:3000'
+      - 3000:3000
     env_file:
       - .env
+    extra_hosts: 
+      - "localdev:0.0.0.0"
   kafka:
     image: spotify/kafka
     ports:


### PR DESCRIPTION
Windows WSL: docker does not redirect external requests to localhost, but it can do if you specify app host to be 0.0.0.0.
Appregistration ReplyURL does not accept ip address so 0.0.0.0 will not work, but only FQDN.
The solution is to trigger the system to listen on alternative FQDN in both docker compose and the the windows system
