### PR TITLE
Reintroduce ingress resource after Traefik v2 byhpass

### DIFF
--- a/dfds-deploy/k8s/ingress.yaml
+++ b/dfds-deploy/k8s/ingress.yaml
@@ -1,0 +1,24 @@
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  name: backstage
+  annotations:
+    traefik.frontend.rule.type: PathPrefixStrip
+  labels:
+    department: cloudengineering
+    project: developerautomation
+    app: backstage
+    component: ingress
+spec:
+  rules:
+  - host: backstage.dfds.cloud
+    http:
+      paths:
+      - backend:
+          serviceName: backstage
+          servicePort: frontend
+        path: /
+      - backend:
+          serviceName: backstage-backend
+          servicePort: backend
+        path: /backend


### PR DESCRIPTION
Reintroduce ingress since Traefik v2 is being bypassed a this point in time.
